### PR TITLE
[45기 양진민] Add: footer 무한스크롤 영역 하단 고정

### DIFF
--- a/public/data/main-court-list.json
+++ b/public/data/main-court-list.json
@@ -1,13 +1,14 @@
 [
   {
     "id": 1,
-    "price": "11000.00",
+    "name": "행복가득",
+    "price": "11000",
     "address": "a",
     "longitude": "",
     "latitude": "",
-    "district": "종로구",
     "ownerId": 1,
     "parking": "공용주차장",
+    "district": "종로구",
     "region": "강북",
     "rentalEquip": 0,
     "showerFacility": 1,
@@ -15,7 +16,8 @@
     "type": "클레이 코트",
     "isIndoor": 0,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": [
+    "isExclusive": 0,
+    "timeSlots": [
       {
         "timeSlot": "2023-05-22 09:00:00.000000",
         "isAvailable": 0
@@ -195,25 +197,82 @@
       {
         "timeSlot": "2023-05-24 23:00:00.000000",
         "isAvailable": 0
+      },
+      {
+        "timeSlot": "2023-05-30 09:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 10:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 11:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 12:00:00.000000",
+        "isAvailable": 0
+      },
+      {
+        "timeSlot": "2023-05-30 13:00:00.000000",
+        "isAvailable": 0
+      },
+      {
+        "timeSlot": "2023-05-30 14:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 15:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 16:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 17:00:00.000000",
+        "isAvailable": 0
+      },
+      {
+        "timeSlot": "2023-05-30 18:00:00.000000",
+        "isAvailable": 0
+      },
+      {
+        "timeSlot": "2023-05-30 19:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 20:00:00.000000",
+        "isAvailable": 0
+      },
+      {
+        "timeSlot": "2023-05-30 21:00:00.000000",
+        "isAvailable": 1
+      },
+      {
+        "timeSlot": "2023-05-30 22:00:00.000000",
+        "isAvailable": 1
       }
     ],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/adam-seckel-caIuSRJEnyE-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/chris-chondrogiannis-oN_rL__KiiU-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/chuttersnap-aRKAzRlRe98-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/chuttersnap-g7wJBNkGIfY-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/gonzalo-facello-_oPHZk_uYXM-unsplash.jpg?raw=true"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court1.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court2.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court3.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court4.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court5.png?raw=true"
     ]
   },
   {
     "id": 2,
-    "price": "11000.00",
+    "name": "행운가득",
+    "price": "11000",
     "address": "b",
     "longitude": "",
     "latitude": "",
-    "district": "종로구",
     "ownerId": 1,
     "parking": "전용주차장",
+    "district": "종로구",
     "region": "강북",
     "rentalEquip": 0,
     "showerFacility": 1,
@@ -221,7 +280,8 @@
     "type": "하드 코트",
     "isIndoor": 0,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": [
+    "isExclusive": 1,
+    "timeSlots": [
       {
         "timeSlot": "2023-05-22 09:00:00.000000",
         "isAvailable": 0
@@ -404,22 +464,23 @@
       }
     ],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/izuddin-helmi-adnan-10LyifFNXJA-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/rodrigo-kugnharski-DnaofMNz0HM-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/ryan-searle-qjrjJnFypa0-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/steffan-mitchell-9h4Xd2Yp3mc-unsplash.jpg?raw=true",
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/tim-chow-iiWhddT4SB4-unsplash.jpg?raw=true"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court6.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court7.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court8.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court9.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court10.png?raw=true"
     ]
   },
   {
     "id": 3,
-    "price": "11000.00",
+    "name": "호랑해",
+    "price": "11000",
     "address": "c",
     "longitude": "",
     "latitude": "",
-    "district": "종로구",
     "ownerId": 1,
     "parking": "없음",
+    "district": "종로구",
     "region": "강북",
     "rentalEquip": 0,
     "showerFacility": 1,
@@ -427,7 +488,8 @@
     "type": "잔디 코트",
     "isIndoor": 0,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": [
+    "isExclusive": 0,
+    "timeSlots": [
       {
         "timeSlot": "2023-05-22 09:00:00.000000",
         "isAvailable": 1
@@ -610,22 +672,23 @@
       }
     ],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/chris-chondrogiannis-oN_rL__KiiU-unsplash.jpg?raw=true",
-      "e",
-      "A",
-      "h",
-      "1"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court11.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court12.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court13.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court14.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court15.png?raw=true"
     ]
   },
   {
     "id": 4,
-    "price": "11000.00",
+    "name": "행복해",
+    "price": "11000",
     "address": "d",
     "longitude": "",
     "latitude": "",
-    "district": "종로구",
     "ownerId": 1,
     "parking": "공용주차장",
+    "district": "종로구",
     "region": "강북",
     "rentalEquip": 1,
     "showerFacility": 1,
@@ -633,7 +696,8 @@
     "type": "카펫 코트",
     "isIndoor": 1,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": [
+    "isExclusive": 1,
+    "timeSlots": [
       {
         "timeSlot": "2023-05-22 09:00:00.000000",
         "isAvailable": 1
@@ -816,22 +880,23 @@
       }
     ],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/chuttersnap-aRKAzRlRe98-unsplash.jpg?raw=true",
-      "A",
-      "y",
-      "h",
-      "h"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court16.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court17.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court18.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court19.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court20.png?raw=true"
     ]
   },
   {
     "id": 5,
-    "price": "15000.00",
+    "name": "기뻐",
+    "price": "15000",
     "address": "e",
     "longitude": "",
     "latitude": "",
-    "district": "중구",
     "ownerId": 1,
     "parking": "전용주차장",
+    "district": "중구",
     "region": "강북",
     "rentalEquip": 1,
     "showerFacility": 1,
@@ -839,7 +904,8 @@
     "type": "우드 코트",
     "isIndoor": 1,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": [
+    "isExclusive": 1,
+    "timeSlots": [
       {
         "timeSlot": "2023-05-22 09:00:00.000000",
         "isAvailable": 0
@@ -1022,22 +1088,23 @@
       }
     ],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/chuttersnap-g7wJBNkGIfY-unsplash.jpg?raw=true",
-      "d",
-      "g",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court2.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court3.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court4.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court5.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court6.png?raw=true"
     ]
   },
   {
     "id": 6,
-    "price": "11000.00",
+    "name": "진짜야",
+    "price": "11000",
     "address": "f",
     "longitude": "",
     "latitude": "",
-    "district": "중구",
-    "ownerId": 1,
+    "ownerId": 2,
     "parking": "없음",
+    "district": "중구",
     "region": "강북",
     "rentalEquip": 1,
     "showerFacility": 1,
@@ -1045,24 +1112,25 @@
     "type": "고무 코트",
     "isIndoor": 1,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": null,
+    "isExclusive": 1,
+    "timeSlots": [],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/gonzalo-facello-_oPHZk_uYXM-unsplash.jpg?raw=true",
-      "A",
-      "A",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court8.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court9.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court10.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court11.png?raw=true"
     ]
   },
   {
     "id": 7,
-    "price": "15000.00",
+    "name": "정말이야",
+    "price": "15000",
     "address": "g",
     "longitude": "",
     "latitude": "",
-    "district": "중구",
-    "ownerId": 1,
+    "ownerId": 2,
     "parking": "공용주차장",
+    "district": "중구",
     "region": "강북",
     "rentalEquip": 1,
     "showerFacility": 0,
@@ -1070,24 +1138,26 @@
     "type": "클레이 코트",
     "isIndoor": 0,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": null,
+    "isExclusive": 0,
+    "timeSlots": [],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/rodrigo-kugnharski-DnaofMNz0HM-unsplash.jpg?raw=true",
-      "A",
-      "A",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court13.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court14.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court16.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court17.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court19.png?raw=true"
     ]
   },
   {
     "id": 8,
-    "price": "15000.00",
+    "name": "믿어줘",
+    "price": "15000",
     "address": "h",
     "longitude": "",
     "latitude": "",
-    "district": "중구",
-    "ownerId": 1,
+    "ownerId": 2,
     "parking": "전용주차장",
+    "district": "중구",
     "region": "강북",
     "rentalEquip": 0,
     "showerFacility": 1,
@@ -1095,24 +1165,26 @@
     "type": "하드 코트",
     "isIndoor": 0,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": null,
+    "isExclusive": 0,
+    "timeSlots": [],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/ryan-searle-qjrjJnFypa0-unsplash.jpg?raw=true",
-      "A",
-      "A",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court20.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court2.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court3.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court4.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court5.png?raw=true"
     ]
   },
   {
     "id": 9,
-    "price": "11000.00",
+    "name": "진짠데",
+    "price": "11000",
     "address": "i",
     "longitude": "",
     "latitude": "",
-    "district": "용산구",
     "ownerId": 2,
     "parking": "없음",
+    "district": "용산구",
     "region": "강북",
     "rentalEquip": 1,
     "showerFacility": 1,
@@ -1120,24 +1192,26 @@
     "type": "잔디 코트",
     "isIndoor": 0,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": null,
+    "isExclusive": 1,
+    "timeSlots": [],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/steffan-mitchell-9h4Xd2Yp3mc-unsplash.jpg?raw=true",
-      "A",
-      "A",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court6.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court8.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court9.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court10.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court11.png?raw=true"
     ]
   },
   {
     "id": 10,
-    "price": "12500.00",
+    "name": "행복해",
+    "price": "12500",
     "address": "j",
     "longitude": "",
     "latitude": "",
-    "district": "용산구",
     "ownerId": 2,
     "parking": "공용주차장",
+    "district": "용산구",
     "region": "강북",
     "rentalEquip": 0,
     "showerFacility": 0,
@@ -1145,24 +1219,26 @@
     "type": "카펫 코트",
     "isIndoor": 1,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": null,
+    "isExclusive": 1,
+    "timeSlots": [],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/tim-chow-iiWhddT4SB4-unsplash.jpg?raw=true",
-      "A",
-      "A",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court13.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court14.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court16.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court17.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court19.png?raw=true"
     ]
   },
   {
     "id": 11,
-    "price": "12500.00",
+    "name": "너무나도",
+    "price": "12500",
     "address": "k",
     "longitude": "",
     "latitude": "",
-    "district": "용산구",
     "ownerId": 2,
     "parking": "전용주차장",
+    "district": "용산구",
     "region": "강북",
     "rentalEquip": 0,
     "showerFacility": 0,
@@ -1170,24 +1246,26 @@
     "type": "우드 코트",
     "isIndoor": 1,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": null,
+    "isExclusive": 1,
+    "timeSlots": [],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/tim-chow-iiWhddT4SB4-unsplash.jpg?raw=true",
-      "A",
-      "A",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court20.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court2.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court3.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court4.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court5.png?raw=true"
     ]
   },
   {
     "id": 12,
-    "price": "11000.00",
+    "name": "호랑해",
+    "price": "11000",
     "address": "l",
     "longitude": "",
     "latitude": "",
-    "district": "용산구",
     "ownerId": 2,
     "parking": "없음",
+    "district": "용산구",
     "region": "강북",
     "rentalEquip": 0,
     "showerFacility": 1,
@@ -1195,13 +1273,211 @@
     "type": "고무 코트",
     "isIndoor": 1,
     "description": "나는 지지않아 짜식아 ",
-    "timeSlot": null,
+    "isExclusive": 1,
+    "timeSlots": [],
     "courtImage": [
-      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/tim-chow-iiWhddT4SB4-unsplash.jpg?raw=true",
-      "A",
-      "A",
-      "A",
-      "A"
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court6.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court8.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court9.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court10.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court11.png?raw=true"
     ]
+  },
+  {
+    "id": 13,
+    "name": "하니해",
+    "price": "15000",
+    "address": "m",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 2,
+    "parking": "공용주차장",
+    "district": "성동구",
+    "region": "강북",
+    "rentalEquip": 0,
+    "showerFacility": 0,
+    "amenities": 0,
+    "type": "클레이 코트",
+    "isIndoor": 0,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 1,
+    "timeSlots": [],
+    "courtImage": [
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court13.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court14.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court17.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court20.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court2.png?raw=true"
+    ]
+  },
+  {
+    "id": 14,
+    "name": "슈아해",
+    "price": "10000",
+    "address": "n",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 3,
+    "parking": "전용주차장",
+    "district": "성동구",
+    "region": "강북",
+    "rentalEquip": 0,
+    "showerFacility": 0,
+    "amenities": 0,
+    "type": "하드 코트",
+    "isIndoor": 0,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 1,
+    "timeSlots": [],
+    "courtImage": [
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court3.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court4.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court6.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court8.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court9.png?raw=true"
+    ]
+  },
+  {
+    "id": 15,
+    "name": "호랑해",
+    "price": "11000",
+    "address": "o",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 3,
+    "parking": "없음",
+    "district": "성동구",
+    "region": "강북",
+    "rentalEquip": 1,
+    "showerFacility": 0,
+    "amenities": 1,
+    "type": "잔디 코트",
+    "isIndoor": 0,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 0,
+    "timeSlots": [],
+    "courtImage": [
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court11.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court13.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court16.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court17.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court20.png?raw=true"
+    ]
+  },
+  {
+    "id": 16,
+    "name": "행복가득",
+    "price": "12500",
+    "address": "p",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 3,
+    "parking": "공용주차장",
+    "district": "성동구",
+    "region": "강북",
+    "rentalEquip": 0,
+    "showerFacility": 1,
+    "amenities": 1,
+    "type": "카펫 코트",
+    "isIndoor": 1,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 0,
+    "timeSlots": [],
+    "courtImage": [
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court3.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court4.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court5.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court8.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court10.png?raw=true"
+    ]
+  },
+  {
+    "id": 17,
+    "name": "호랑해",
+    "price": "15000",
+    "address": "q",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 3,
+    "parking": "전용주차장",
+    "district": "광진구",
+    "region": "강북",
+    "rentalEquip": 0,
+    "showerFacility": 0,
+    "amenities": 1,
+    "type": "우드 코트",
+    "isIndoor": 1,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 1,
+    "timeSlots": [],
+    "courtImage": [
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court11.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court14.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court16.png?raw=true",
+      "https://github.com/haaazzi/images-for-assemble-project/blob/add/images/court19.png?raw=true"
+    ]
+  },
+  {
+    "id": 18,
+    "name": "행복가득",
+    "price": "10000",
+    "address": "r",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 4,
+    "parking": "없음",
+    "district": "광진구",
+    "region": "강북",
+    "rentalEquip": 0,
+    "showerFacility": 0,
+    "amenities": 0,
+    "type": "고무 코트",
+    "isIndoor": 1,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 1,
+    "timeSlots": [],
+    "courtImage": []
+  },
+  {
+    "id": 19,
+    "name": "하니해",
+    "price": "11000",
+    "address": "s",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 4,
+    "parking": "공용주차장",
+    "district": "광진구",
+    "region": "강북",
+    "rentalEquip": 1,
+    "showerFacility": 0,
+    "amenities": 0,
+    "type": "클레이 코트",
+    "isIndoor": 0,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 0,
+    "timeSlots": [],
+    "courtImage": []
+  },
+  {
+    "id": 20,
+    "name": "호랑해",
+    "price": "10000",
+    "address": "t",
+    "longitude": "",
+    "latitude": "",
+    "ownerId": 4,
+    "parking": "전용주차장",
+    "district": "광진구",
+    "region": "강북",
+    "rentalEquip": 1,
+    "showerFacility": 1,
+    "amenities": 0,
+    "type": "하드 코트",
+    "isIndoor": 0,
+    "description": "나는 지지않아 짜식아 ",
+    "isExclusive": 1,
+    "timeSlots": [],
+    "courtImage": []
   }
 ]

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,9 +1,20 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router";
 import styled from "styled-components";
 
 const Footer = () => {
+  const location = useLocation();
+  const footerFixed = URL_LIST.includes(location.pathname);
+  const [windowSize, setWindowSize] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleWindowResize = () => setWindowSize(window.innerWidth);
+    window.addEventListener("resize", handleWindowResize);
+    return () => window.removeEventListener("resize", handleWindowResize);
+  }, []);
+
   return (
-    <FooterArea>
+    <FooterArea primary={footerFixed}>
       <FooterTop>
         <CompanyArea>
           <div>© ${new Date().getFullYear()} Assemble, Inc</div>
@@ -32,21 +43,26 @@ const Footer = () => {
           </ul>
         </LanguageAndSocial>
       </FooterTop>
-      <FooterBottom>
-        웹사이트 제공자: Assemble Ireland UC, private unlimited company, 8
-        Hanover Quay Dublin 2, D02 DP23 Ireland | 이사: Jinmin Yang, Jihuyn Ha,
-        Sujeong Kim | VAT 번호: IE111L | 사업자 등록 번호: IE 111111 | 연락처:
-        matching@assemble.com, 웹사이트, 080-111-1111 | 호스팅 서비스 제공업체:
-        아마존 웹서비스 | Assemble은 통신판매 중개자로 Assemble 플랫폼을 통하여
-        게스트와 호스트 사이에 이루어지는 통신판매의 당사자가 아닙니다. Assemble
-        플랫폼을 통하여 예약된 체육관, 체험, 호스트 서비스에 관한 의무와 책임은
-        해당 서비스를 제공하는 호스트에게 있습니다.
-      </FooterBottom>
+      {(footerFixed && windowSize <= 1160) || (
+        <FooterBottom>
+          웹사이트 제공자: Assemble Ireland UC, private unlimited company, 8
+          Hanover Quay Dublin 2, D02 DP23 Ireland | 이사: Jinmin Yang, Jihuyn
+          Ha, Sujeong Kim | VAT 번호: IE111L | 사업자 등록 번호: IE 111111 |
+          연락처: matching@assemble.com, 웹사이트, 080-111-1111 | 호스팅 서비스
+          제공업체: 아마존 웹서비스 | Assemble은 통신판매 중개자로 Assemble
+          플랫폼을 통하여 게스트와 호스트 사이에 이루어지는 통신판매의 당사자가
+          아닙니다. Assemble 플랫폼을 통하여 예약된 체육관, 체험, 호스트
+          서비스에 관한 의무와 책임은 해당 서비스를 제공하는 호스트에게
+          있습니다.
+        </FooterBottom>
+      )}
     </FooterArea>
   );
 };
 
 export default Footer;
+
+const URL_LIST = [`/`, `/Matching`];
 
 const FOOTER_BOTTOM_LEFT_MENUS = [
   { id: 1, name: `개인정보 처리방침` },
@@ -64,10 +80,12 @@ const FOOTER_BOTTOM_RIGHT_ICON_MENUS = [
 ];
 
 const FooterArea = styled.div`
+  position: ${props => props.primary && `fixed`};
+  bottom: 0px;
   border-top: 1px solid #d9d9d9;
   background-color: #f7f7f7;
   white-space: pre-wrap;
-  max-width: 1280px;
+  width: 100%;
   margin: 0 auto;
   padding: 0 40px;
   display: flex;
@@ -82,11 +100,12 @@ const FooterTop = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 14px 0;
-
+  max-width: 1280px;
+  width: 100%;
+  margin: 0px auto;
   @media screen and (max-width: 1126px) {
     flex-direction: column-reverse;
   }
-
   @media screen and (max-width: 550px) {
     flex-direction: column-reverse;
     display: flex;
@@ -131,6 +150,9 @@ const Social = styled.li`
 `;
 
 const FooterBottom = styled.div`
+  max-width: 1280px;
+  width: 100%;
+  margin: 0px auto;
   border-top: 1px solid #d9d9d9;
   padding: 8px 0;
   font-size: 11px;


### PR DESCRIPTION
## 1. 본 PR이 우리 팀의 웹 서비스 제품성에 어떠한 기여를 하였고, 사용자에게 어떠한 기대효과를 전달하는지 작성해주세요.
- 내 PR이 제품 내 어떠한 기능적인 배경/전후맥락 가운데 개발되었나요?
  - 무한 스크롤시에도 footer 영역을 표시할 수 있도록 개발했습니다.

- 내 PR이 Merge 됨으로써 유저에게 전달되는 편익/기대효과는 무엇일까요?
  - 유저는 footer의 필요한 정보를 무한 스크롤 중에도 볼 수 있습니다. 

## 2. 이 브랜치에서 어떤 내용을 개발했는지 큰 제목과 그리고 상세 내역을 적어주세요.
- 무한 스크롤 페이지에만 footer가 하단에 fix 됨
- fix된 페이지에서 반응형을 줄 경우 아래 하단 라인이 숨겨짐

## 3. 개발한 화면을 캡쳐해서 첨부 해 주세요. (drag & drop 또는 첨부파일 추가)

![image](https://github.com/wecode-bootcamp-korea/45-2nd-Assemble-frontend/assets/86812072/2712da81-83f2-4b7e-8bf0-0096de5b7ae0)
![image](https://github.com/wecode-bootcamp-korea/45-2nd-Assemble-frontend/assets/86812072/cb3c01c4-fd26-4207-983d-b8d5f6fdec00)
![image](https://github.com/wecode-bootcamp-korea/45-2nd-Assemble-frontend/assets/86812072/990fc793-1291-4ff3-b1a3-512d2db76cfc)


## 4. 이 브랜치에서 개발하면서 느꼇던 개발 성장포인트를 적어주세요.
- 자바스크립트의 resize 개념을 알았습니다
